### PR TITLE
fix: mimalloc virtual memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,12 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "cc"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,7 +56,6 @@ version = "1.1.0"
 dependencies = [
  "geohash",
  "lazy_static",
- "mimalloc",
  "pyo3",
  "pyo3-build-config",
 ]
@@ -92,16 +85,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ac0e912c8ef1b735e92369695618dc5b1819f5a7bf3f167301a3ba1cea515e"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,15 +101,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2894987a3459f3ffb755608bd82188f8ed00d0ae077f1edea29c068d639d98"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ name = "_geohashr"
 crate-type = ["cdylib"]
 
 [dependencies]
-mimalloc = { version = "0.1.37", default-features = false, features = ["local_dynamic_tls"] }
 geohash = { version = "=0.13" }
 pyo3 = { version = "=0.19", features = ["extension-module"] }
 lazy_static = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use std::collections::HashMap;
 
 use geohash::{self, Direction};
@@ -18,7 +15,7 @@ create_exception!(_geohashr, ParamError, PySyntaxError, "Geohash parameter error
 
 enum NeighborError {
     Hash(geohash::GeohashError),
-    Direction
+    Direction,
 }
 
 lazy_static! {
@@ -53,7 +50,7 @@ fn decode_exact(py: Python, hash: &str) -> PyResult<(f64, f64, f64, f64)> {
 }
 
 #[pyfunction]
-#[pyo3(signature = (lat, lon, len=12))]
+#[pyo3(signature = (lat, lon, len = 12))]
 fn encode(py: Python, lat: f64, lon: f64, len: usize) -> PyResult<String> {
     match py.allow_threads(|| geohash::encode(geohash::Coord { x: lon, y: lat }, len)) {
         Ok(hash) => Ok(hash),


### PR DESCRIPTION
About mimalloc allocing too much virtual memory: https://github.com/pydantic/pydantic/issues/7167

This is use mimalloc:

![image](https://github.com/gi0baro/geohashr/assets/43594924/6c723cef-87b9-479f-86b0-523f9afc4910)


Not use mimalloc:

![image](https://github.com/gi0baro/geohashr/assets/43594924/25a0a3b0-ee77-487b-bc65-b59350b45647)



Finally added pre-commit.